### PR TITLE
No longer build latest and unstable tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,9 +14,9 @@ jobs:
     uses: swissgrc/.github/.github/workflows/publish-image.yml@main
     with:
       image-name: swissgrc/azure-pipelines-sonarscannermsbuild
-      default-latest-tag: true
+      default-latest-tag: false
       additional-latest-tag-name: 7
-      default-unstable-tag: true
+      default-unstable-tag: false
       additional-unstable-tag-name: 7-unstable
     secrets:
       gh-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
No longer build latest and unstable tag from this repository, since .NET 8 is now the latest version